### PR TITLE
Resolve TODO from https://github.com/filmil/bazel-bats/pull/4

### DIFF
--- a/integration/BUILD.bazel
+++ b/integration/BUILD.bazel
@@ -39,10 +39,7 @@ bats_test(
 bats_test(
     name = "hello_world_data_test",
     srcs = ["hello_world_data.bats"],
-    # TODO: Test depends on https://github.com/filmil/bazel-bats/pull/4.
-    # Remove 'manual' tag and uncomment 'data' once that is merged.
-    # data = ["testdata/golden_4.txt"],
-    tags = ["manual"],
+    data = ["testdata/golden_4.txt"],
 )
 
 bats_test(

--- a/integration/WORKSPACE
+++ b/integration/WORKSPACE
@@ -2,14 +2,16 @@ workspace(name = "bazel_bats_integration")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-BAZEL_BATS_VERSION = "0.29.1"
+BAZEL_BATS_VERSION = "05902c66e7aba5bca0816109e9f34e2dbebe19f6"
 
 http_archive(
     name = "bazel_bats",
-    sha256 = "94aea504205cee5f00d9182975a95a5dadf1747fecb75f7d93e09cccc1c19803",
+    sha256 = "0be1795d8052c54e1068b3b0a648d67de0b9bf43cd15fd7bef73b6460b73b78f",
     strip_prefix = "bazel-bats-%s" % BAZEL_BATS_VERSION,
     urls = [
-        "https://github.com/filmil/bazel-bats/archive/refs/tags/v%s.tar.gz" % BAZEL_BATS_VERSION,
+        # NOTE: The following URL can be used if BAZEL_BATS_VERSION is a tag reference.
+        # "https://github.com/filmil/bazel-bats/archive/refs/tags/v%s.tar.gz" % BAZEL_BATS_VERSION,
+        "https://github.com/filmil/bazel-bats/archive/%s.tar.gz" % BAZEL_BATS_VERSION,
     ],
 )
 


### PR DESCRIPTION
Re-enables `hello_world_data_test` by pointing the integration workspace to HEAD.