### PR TITLE
Updating bats-core Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ In your `WORKSPACE` file load and include as follows:
 ```
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-BAZEL_BATS_VERSION = "0.29.1"
+BAZEL_BATS_VERSION = "0.30.0"
+BAZEL_BATS_SHA256 = "9ae647d2db3aa0bd36af84a0a864dce1c4a1c4f7207b240d3a809862944ecb18"
 
 http_archive(
     name = "bazel_bats",
@@ -19,12 +20,12 @@ http_archive(
     urls = [
         "https://github.com/filmil/bazel-bats/archive/refs/tags/v%s.tar.gz" % BAZEL_BATS_VERSION,
     ],
-    sha256 = "94aea504205cee5f00d9182975a95a5dadf1747fecb75f7d93e09cccc1c19803",
+    sha256 = BAZEL_BATS_SHA256,
 )
 
 load("@bazel_bats//:deps.bzl", "bazel_bats_dependencies")
 
-# 'version' and 'sha256' of bats-core can be provided to override the version of v1.1.0.
+# 'version' and 'sha256' of bats-core can be provided to override the version of v1.5.0.
 bazel_bats_dependencies()
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,20 @@ http_archive(
 
 load("@bazel_bats//:deps.bzl", "bazel_bats_dependencies")
 
-# 'version' and 'sha256' of bats-core can be provided to override the version of v1.5.0.
 bazel_bats_dependencies()
+```
+
+You can alternatively specify the specific bats-core version.
+
+```
+BATS_CORE_VERSION = "1.7.0"
+BATS_CORE_SHA256 = "ac70c2a153f108b1ac549c2eaa4154dea4a7c1cc421e3352f0ce6ea49435454e"
+
+# ...
+
+bazel_bats_dependencies(
+    version = BATS_CORE_VERSION,
+    sha256 = BATS_CORE_SHA256)
 ```
 
 In your `BUILD.bazel` file add the following:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,6 +2,11 @@
 # https://stackoverflow.com/questions/47192668/idiomatic-retrieval-of-the-bazel-execution-path#
 workspace(name = "bazel_bats")
 
+BATS_CORE_VERSION = "1.7.0"
+BATS_CORE_SHA256 = "ac70c2a153f108b1ac549c2eaa4154dea4a7c1cc421e3352f0ce6ea49435454e"
+
 load("@bazel_bats//:deps.bzl", "bazel_bats_dependencies")
 
-bazel_bats_dependencies()
+bazel_bats_dependencies(
+    version = BATS_CORE_VERSION,
+    sha256 = BATS_CORE_SHA256)

--- a/deps.bzl
+++ b/deps.bzl
@@ -67,8 +67,12 @@ exports_files(glob(["test/*.bats"]))
 """
 
 def bazel_bats_dependencies(
-        version = "1.5.0",
-        sha256 = "36a3fd4413899c0763158ae194329af8f48bb1ff0d1338090b80b3416d5793af"):
+    version = "1.7.0",
+    sha256 = "ac70c2a153f108b1ac549c2eaa4154dea4a7c1cc421e3352f0ce6ea49435454e"
+):
+    if not sha256:
+        fail("sha256 for bats core not supplied.")
+
     http_archive(
         name = "bats_core",
         build_file_content = BATS_CORE_BUILD,

--- a/deps.bzl
+++ b/deps.bzl
@@ -71,7 +71,7 @@ def bazel_bats_dependencies(
     sha256 = "ac70c2a153f108b1ac549c2eaa4154dea4a7c1cc421e3352f0ce6ea49435454e"
 ):
     if not sha256:
-        fail("sha256 for bats core not supplied.")
+        fail("sha256 for bats-core was not supplied.")
 
     http_archive(
         name = "bats_core",


### PR DESCRIPTION
* Updating bazel_bats_dependencies()'s default version value (and corresponding SHA) to 1.7.0 (~~latest bats-core version~~a newer version, we can update again later).
* Updating WORKSPACE to be more explicit in versions used.
* Adding param checking to ensure that the SHA was passed in.
* Updating README to show explicit version passing.

Merge this PR after https://github.com/filmil/bazel-bats/pull/8 (diff will also be easier to read once that PR is merged).

Submitting as separate PRs to more easily see what is changing. :smile: 