### PR TITLE
Adding Optional bats-core Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ In your `WORKSPACE` file load and include as follows:
 ```
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-BAZEL_BATS_VERSION = "0.29.1"
+BAZEL_BATS_VERSION = "0.30.0"
+BAZEL_BATS_SHA256 = "9ae647d2db3aa0bd36af84a0a864dce1c4a1c4f7207b240d3a809862944ecb18"
 
 http_archive(
     name = "bazel_bats",
@@ -19,12 +20,12 @@ http_archive(
     urls = [
         "https://github.com/filmil/bazel-bats/archive/refs/tags/v%s.tar.gz" % BAZEL_BATS_VERSION,
     ],
-    sha256 = "94aea504205cee5f00d9182975a95a5dadf1747fecb75f7d93e09cccc1c19803",
+    sha256 = BAZEL_BATS_SHA256,
 )
 
 load("@bazel_bats//:deps.bzl", "bazel_bats_dependencies")
 
-# 'version' and 'sha256' of bats-core can be provided to override the version of v1.1.0.
+# 'version' and 'sha256' of bats-core can be provided to override the version of v1.5.0.
 bazel_bats_dependencies()
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ bazel_bats_dependencies(
     bats_assert_version = BATS_ASSERT_VERSION,
     bats_assert_sha256 = BATS_ASSERT_SHA256,
     bats_support_version = BATS_SUPPORT_VERSION,
-    bats_support_sha256 = BATS_SUPPORT_SHA256)
+    bats_support_sha256 = BATS_SUPPORT_SHA256
+)
 ```
 
 In your `BUILD.bazel` file add the following:

--- a/README.md
+++ b/README.md
@@ -28,17 +28,26 @@ load("@bazel_bats//:deps.bzl", "bazel_bats_dependencies")
 bazel_bats_dependencies()
 ```
 
-You can alternatively specify the specific bats-core version.
+You can alternatively specify the specific bats-core version, as well as optionally adding bats-core extensions.
 
 ```
+BATS_ASSERT_VERSION = "2.0.0"
+BATS_ASSERT_SHA256 = "15dbf1abb98db785323b9327c86ee2b3114541fe5aa150c410a1632ec06d9903"
 BATS_CORE_VERSION = "1.7.0"
 BATS_CORE_SHA256 = "ac70c2a153f108b1ac549c2eaa4154dea4a7c1cc421e3352f0ce6ea49435454e"
+BATS_SUPPORT_VERSION = "0.3.0"
+BATS_SUPPORT_SHA256 = "7815237aafeb42ddcc1b8c698fc5808026d33317d8701d5ec2396e9634e2918f"
 
 # ...
 
 bazel_bats_dependencies(
     version = BATS_CORE_VERSION,
-    sha256 = BATS_CORE_SHA256)
+    sha256 = BATS_CORE_SHA256,
+    # Optional test extensions
+    bats_assert_version = BATS_ASSERT_VERSION,
+    bats_assert_sha256 = BATS_ASSERT_SHA256,
+    bats_support_version = BATS_SUPPORT_VERSION,
+    bats_support_sha256 = BATS_SUPPORT_SHA256)
 ```
 
 In your `BUILD.bazel` file add the following:

--- a/README.md
+++ b/README.md
@@ -25,8 +25,20 @@ http_archive(
 
 load("@bazel_bats//:deps.bzl", "bazel_bats_dependencies")
 
-# 'version' and 'sha256' of bats-core can be provided to override the version of v1.5.0.
 bazel_bats_dependencies()
+```
+
+You can alternatively specify the specific bats-core version.
+
+```
+BATS_CORE_VERSION = "1.7.0"
+BATS_CORE_SHA256 = "ac70c2a153f108b1ac549c2eaa4154dea4a7c1cc421e3352f0ce6ea49435454e"
+
+# ...
+
+bazel_bats_dependencies(
+    version = BATS_CORE_VERSION,
+    sha256 = BATS_CORE_SHA256)
 ```
 
 In your `BUILD.bazel` file add the following:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,6 +2,11 @@
 # https://stackoverflow.com/questions/47192668/idiomatic-retrieval-of-the-bazel-execution-path#
 workspace(name = "bazel_bats")
 
+BATS_CORE_VERSION = "1.7.0"
+BATS_CORE_SHA256 = "ac70c2a153f108b1ac549c2eaa4154dea4a7c1cc421e3352f0ce6ea49435454e"
+
 load("@bazel_bats//:deps.bzl", "bazel_bats_dependencies")
 
-bazel_bats_dependencies()
+bazel_bats_dependencies(
+    version = BATS_CORE_VERSION,
+    sha256 = BATS_CORE_SHA256)

--- a/deps.bzl
+++ b/deps.bzl
@@ -2,7 +2,7 @@
 # https://stackoverflow.com/questions/47192668/idiomatic-retrieval-of-the-bazel-execution-path#
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-BATS_CORE_BUILD="""
+_BATS_CORE_BUILD = """
 sh_library(
     name = "bats_lib",
     srcs = glob(["libexec/**"]),
@@ -66,19 +66,75 @@ sh_library(
 exports_files(glob(["test/*.bats"]))
 """
 
+_BATS_ASSERT_BUILD = """
+filegroup(
+    name = "load_files",
+    srcs = [
+        "load.bash",
+        "src/assert.bash",
+    ],
+    visibility = ["//visibility:public"],
+)
+"""
+
+_BATS_SUPPORT_BUILD = """
+filegroup(
+    name = "load_files",
+    srcs = [
+        "load.bash",
+        "src/error.bash",
+        "src/lang.bash",
+        "src/output.bash",
+    ],
+    visibility = ["//visibility:public"],
+)
+"""
+
 def bazel_bats_dependencies(
     version = "1.7.0",
     sha256 = "ac70c2a153f108b1ac549c2eaa4154dea4a7c1cc421e3352f0ce6ea49435454e"
-):
+    bats_assert_version = None,
+    bats_assert_sha256 = None,
+    bats_support_version = None,
+    bats_support_sha256 = None):
+
     if not sha256:
         fail("sha256 for bats core not supplied.")
 
     http_archive(
         name = "bats_core",
-        build_file_content = BATS_CORE_BUILD,
+        build_file_content = _BATS_CORE_BUILD,
         urls = [
             "https://github.com/bats-core/bats-core/archive/refs/tags/v%s.tar.gz" % version,
         ],
         strip_prefix = "bats-core-%s" % version,
         sha256 = sha256,
     )
+
+    if bats_assert_version and not bats_support_version:
+        fail("bats assert version set, but missing set version for dependency bats support.")
+
+    if bats_assert_version:
+        if not bats_assert_sha256:
+            fail("sha256 for bats assert not supplied.")
+        http_archive(
+            name = "bats_assert",
+            build_file_content = _BATS_ASSERT_BUILD,
+            sha256 = bats_assert_sha256,
+            strip_prefix = "bats-assert-%s" % bats_assert_version,
+            urls = [
+                "https://github.com/bats-core/bats-assert/archive/refs/tags/v%s.tar.gz" % bats_assert_version,
+            ],
+        )
+    if bats_support_version:
+        if not bats_support_sha256:
+            fail("sha256 for bats support not supplied.")
+        http_archive(
+            name = "bats_support",
+            build_file_content = _BATS_SUPPORT_BUILD,
+            sha256 = bats_support_sha256,
+            strip_prefix = "bats-support-%s" % bats_support_version,
+            urls = [
+                "https://github.com/bats-core/bats-support/archive/refs/tags/v%s.tar.gz" % bats_support_version,
+            ],
+        )

--- a/deps.bzl
+++ b/deps.bzl
@@ -97,7 +97,7 @@ def bazel_bats_dependencies(
     bats_assert_sha256 = None,
     bats_support_version = None,
     bats_support_sha256 = None
-    ):
+):
 
     if not sha256:
         fail("sha256 for bats-core was not supplied.")

--- a/deps.bzl
+++ b/deps.bzl
@@ -67,8 +67,12 @@ exports_files(glob(["test/*.bats"]))
 """
 
 def bazel_bats_dependencies(
-        version = "1.5.0",
-        sha256 = "36a3fd4413899c0763158ae194329af8f48bb1ff0d1338090b80b3416d5793af"):
+    version = "1.7.0",
+    sha256 = "ac70c2a153f108b1ac549c2eaa4154dea4a7c1cc421e3352f0ce6ea49435454e"
+):
+    if not sha256:
+        fail("sha256 for bats core not supplied.")
+
     http_archive(
         name = "bats_core",
         build_file_content = BATS_CORE_BUILD,

--- a/deps.bzl
+++ b/deps.bzl
@@ -92,7 +92,7 @@ filegroup(
 
 def bazel_bats_dependencies(
     version = "1.7.0",
-    sha256 = "ac70c2a153f108b1ac549c2eaa4154dea4a7c1cc421e3352f0ce6ea49435454e"
+    sha256 = "ac70c2a153f108b1ac549c2eaa4154dea4a7c1cc421e3352f0ce6ea49435454e",
     bats_assert_version = None,
     bats_assert_sha256 = None,
     bats_support_version = None,

--- a/deps.bzl
+++ b/deps.bzl
@@ -96,7 +96,8 @@ def bazel_bats_dependencies(
     bats_assert_version = None,
     bats_assert_sha256 = None,
     bats_support_version = None,
-    bats_support_sha256 = None):
+    bats_support_sha256 = None
+    ):
 
     if not sha256:
         fail("sha256 for bats-core was not supplied.")

--- a/deps.bzl
+++ b/deps.bzl
@@ -98,7 +98,6 @@ def bazel_bats_dependencies(
     bats_support_version = None,
     bats_support_sha256 = None
 ):
-
     if not sha256:
         fail("sha256 for bats-core was not supplied.")
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -99,7 +99,7 @@ def bazel_bats_dependencies(
     bats_support_sha256 = None):
 
     if not sha256:
-        fail("sha256 for bats core not supplied.")
+        fail("sha256 for bats-core was not supplied.")
 
     http_archive(
         name = "bats_core",
@@ -113,9 +113,9 @@ def bazel_bats_dependencies(
 
     if bats_assert_version:
         if not bats_support_version:
-            fail("bats assert version set, but missing set version for dependency bats support.")
+            fail("bats-assert version was set, but was missing set version for dependency bats-support.")
         if not bats_assert_sha256:
-            fail("sha256 for bats assert not supplied.")
+            fail("sha256 for bats-assert was not supplied.")
         http_archive(
             name = "bats_assert",
             build_file_content = _BATS_ASSERT_BUILD,
@@ -127,7 +127,7 @@ def bazel_bats_dependencies(
         )
     if bats_support_version:
         if not bats_support_sha256:
-            fail("sha256 for bats support not supplied.")
+            fail("sha256 for bats-support was not supplied.")
         http_archive(
             name = "bats_support",
             build_file_content = _BATS_SUPPORT_BUILD,

--- a/deps.bzl
+++ b/deps.bzl
@@ -111,10 +111,9 @@ def bazel_bats_dependencies(
         sha256 = sha256,
     )
 
-    if bats_assert_version and not bats_support_version:
-        fail("bats assert version set, but missing set version for dependency bats support.")
-
     if bats_assert_version:
+        if not bats_support_version:
+            fail("bats assert version set, but missing set version for dependency bats support.")
         if not bats_assert_sha256:
             fail("sha256 for bats assert not supplied.")
         http_archive(


### PR DESCRIPTION
Extending bazel_bats_dependencies() to also (optionally) allow for adding in bats extensions, bats-assert and bats-support (bats-support is required for bats-assert).

The decision to make these optional additions was made to not force extra dependencies on any downstream library that does not make use of them (dep management is good).
The `bats_test()` rule will be updated in a follow-up PR.

Merge this PR after https://github.com/filmil/bazel-bats/pull/9 (diff will also be easier to read once that PR is merged).
Merge this PR before https://github.com/filmil/bazel-bats/pull/11.

Submitting as separate PRs to more easily see what is changing. :smile: 