### PR TITLE
Fixing Parallel Lib Deps

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -33,7 +33,10 @@ sh_library(
     name = "parallel_lib",
     srcs = ["test/parallel.bats"],
     visibility = ["//visibility:public"],
-    data = glob(["test/fixtures/parallel/**"]),
+    data = glob([
+        "test/concurrent-coordination.bash",
+        "test/fixtures/parallel/**",
+    ]),
 )
 
 sh_library(


### PR DESCRIPTION
* Adding `test/concurrent-coordination.bash` to `data` list on `parallel_lib`.
  * This file is loaded by "test/fixtures/parallel/parallel.bats", so it should be available at runtime.
  * Although the parallel test is currently disabled, this is still a necessary fix for when it is eventually re-enabled.