### PR TITLE
Add `bats_test_suite` rule

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -146,9 +146,6 @@ def bats_test_suite(name, srcs, **kwargs):
     tests = []
 
     for src in srcs:
-        if not src.endswith(".bats"):
-            fail("srcs should have `.bats` extensions")
-
         # Prefixed with `name` to allow parameterization with macros
         # The test name should not end with `.bats`
         test_name = name + "_" + src[:-5]

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel_bats//:rules.bzl", "bats_test")
+load("@bazel_bats//:rules.bzl", "bats_test", "bats_test_suite")
 
 sh_binary(
     name = "exit_with_input_bin",
@@ -86,4 +86,12 @@ bats_test(
 filegroup(
     name = "dummy",
     srcs = ["dummy.txt"],
+)
+
+bats_test_suite(
+    name = "test_suite",
+    srcs = [
+        "hello_world_1.bats",
+        "hello_world_2.bats",
+    ]
 )


### PR DESCRIPTION
The rule can generate `bats_test` targets for each source file and a `test_suite`, which encapsulates all tests.

With this rule, one can write a single test suite encapsulating all tests from a source while still being able to run the individual tests.