### PR TITLE
Env Var Expansion and Cleanup

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,6 +10,7 @@ BATS_SUPPORT_VERSION = "0.3.0"
 BATS_SUPPORT_SHA256 = "7815237aafeb42ddcc1b8c698fc5808026d33317d8701d5ec2396e9634e2918f"
 
 load("@bazel_bats//:deps.bzl", "bazel_bats_dependencies")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 bazel_bats_dependencies(
     version = BATS_CORE_VERSION,
@@ -18,4 +19,16 @@ bazel_bats_dependencies(
     bats_assert_sha256 = BATS_ASSERT_SHA256,
     bats_support_version = BATS_SUPPORT_VERSION,
     bats_support_sha256 = BATS_SUPPORT_SHA256
+)
+
+# Used for testing support/compatibility with `string_flag()` from
+# `@bazel_skylib//rules:common_settings.bzl` (specifically testing make variable support).
+# TODO: Update from `git_repository()` to `http_archive()` once a tag/release >1.4.2 is out.
+#       Specifically looking for changes from https://github.com/bazelbuild/bazel-skylib/pull/440.
+#       See https://github.com/bazelbuild/bazel-skylib/issues/471.
+git_repository(
+    name = "bazel_skylib",
+    # Latest `main` commit that contains desired changes.
+    commit = "652c8f0b2817daaa2570b7a3b2147643210f7dc7",
+    remote = "https://github.com/bazelbuild/bazel-skylib.git",
 )

--- a/deps.bzl
+++ b/deps.bzl
@@ -74,8 +74,9 @@ filegroup(
     name = "load_files",
     srcs = [
         "load.bash",
-        "src/assert.bash",
-    ],
+    ] + glob([
+        "src/**/*.bash",
+    ]),
     visibility = ["//visibility:public"],
 )
 """
@@ -85,10 +86,9 @@ filegroup(
     name = "load_files",
     srcs = [
         "load.bash",
-        "src/error.bash",
-        "src/lang.bash",
-        "src/output.bash",
-    ],
+    ] + glob([
+        "src/**/*.bash",
+    ]),
     visibility = ["//visibility:public"],
 )
 """

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_bats//:rules.bzl", "bats_test", "bats_test_suite")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 sh_binary(
     name = "exit_with_input_bin",
@@ -57,8 +58,12 @@ bats_test(
     env = {
         "PROGRAM": "hello_world",
         "LOCATED": "$(location :dummy)",
+        "TOOLCHAIN_STRING_FLAG_ENV_VAR": "$(STRING_FLAG_ENV_VAR)",
     },
     deps = [":dummy"],
+    toolchains = [
+        ":hello_world_flag",
+    ],
 )
 
 bats_test(
@@ -94,4 +99,10 @@ bats_test_suite(
         "hello_world_1.bats",
         "hello_world_2.bats",
     ]
+)
+
+string_flag(
+    name = "hello_world_flag",
+    build_setting_default = "flag_value",
+    make_variable = "STRING_FLAG_ENV_VAR",
 )

--- a/tests/hello_world.bats
+++ b/tests/hello_world.bats
@@ -5,11 +5,16 @@
   [ "$result" -eq 4 ]
 }
 
-@test "Test program name" {
+@test "Test simple environment variable" {
   [ "${PROGRAM}" == "hello_world" ]
 }
 
-@test "Test program name with location" {
+@test "Test environment variable expanded from bazel location" {
   echo "Location: ${LOCATED}"
   [ "${LOCATED}" == "tests/dummy.txt" ]
+}
+
+@test "Test environment variable expanded from bazel string flag" {
+  echo "Flag env var: ${TOOLCHAIN_STRING_FLAG_ENV_VAR}"
+  [ "${TOOLCHAIN_STRING_FLAG_ENV_VAR}" == "flag_value" ]
 }


### PR DESCRIPTION
`TemplateVariableInfo` provides a mechanism for custom make variable expansion.

`string_flag()` contains a simple (pre-built) way to generate flags. This be used with `config_setting()` and can be set via commandline (without `--define`). `TemplateVariableInfo` support was added to `string_flag()` in https://github.com/bazelbuild/bazel-skylib/pull/440.

Many other Bazel target rules support make variable expansion on many attributes (e.g. `env`). This PR adds support for `TemplateVariableInfo` (e.g. via `string_flag()`  or other custom rule) to bats bazel test rules on the `env` attribute.

Changes:
* Adding call to `ctx.expand_make_variables()` in `_bats_test_impl()`.
  * This is done in addition to (after) expansion for `$(location ...)`.
* Updating `:hello_world_test` (which tests `env` attribute usage) to also test flag-driven envs.
* Adding `@bazel_skylib` to workspace.
  * Only used to declare/reference `string_flag()` in `tests/BUILD.bazel`.
  * While this could have been simply covered by a custom rule (to return a `TemplateVariableInfo`) in a test-specific `.bzl` file, it seemed better to just use the common (external/pre-existing) rule.
  * Refenced via `git_repository()` (instead of `http_archive()`) as the necessary changes are not yet in a tag/release.
  * Only affects tests, and thus does not cause any extra transitive dependencies on libraries that use this project.
* Misc other changes:
  * Updating bats-support and bats-assert rules to use `glob()`.
    * Supports newer versions, which separated out contents into multiple `.bash` files.
    * More flexible than naming exact file names.
  * Replacing attribute dict `update()` call with dict concat operator `|`.
  * Renaming some test cases in `hello_world.bats`.

See https://bazel.build/rules/lib/providers/TemplateVariableInfo, https://bazel.build/docs/configurable-attributes, https://bazel.build/reference/be/general#config_setting, https://bazel.build/extending/config#defining-build-settings