### PR TITLE
Passing CLI Test Arguments

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -8,7 +8,7 @@ def _dirname(path):
     return prefix.rstrip("/")
 
 def _test_files(bats, srcs, attr):
-    return '"{bats_bin}" {bats_args} {test_paths}'.format(
+    return '"{bats_bin}" {bats_args} "$@" {test_paths}'.format(
         bats_bin = bats.short_path,
         bats_args = " ".join(attr.bats_args),
         test_paths = " ".join(['"{}"'.format(s.short_path) for s in srcs]),


### PR DESCRIPTION
* Adding `"$@"` to bats test wrapper script.
  * This passes through any arguments given to the wrapper script from the command line.
  * Compatible with Bazel's `--test_arg`.
  * Allows passing Bats arguments to tests, like `--count`, `--filter`, etc.
  * Arguments added to bats arguments after `{bats_args}` to allow precedence/overriding target defined arguments with CLI arguments (where compatible).
  * If no CLI arguments are passed, this is noop.