### PR TITLE
Easier External Repo Definitions

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -2,7 +2,7 @@
 # https://stackoverflow.com/questions/47192668/idiomatic-retrieval-of-the-bazel-execution-path#
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-_BATS_CORE_BUILD = """
+BATS_CORE_BUILD_CONTENT = """
 sh_library(
     name = "bats_lib",
     srcs = glob(["libexec/**"]),
@@ -69,7 +69,7 @@ sh_library(
 exports_files(glob(["test/*.bats"]))
 """
 
-_BATS_ASSERT_BUILD = """
+BATS_ASSERT_BUILD_CONTENT = """
 filegroup(
     name = "load_files",
     srcs = [
@@ -81,7 +81,7 @@ filegroup(
 )
 """
 
-_BATS_SUPPORT_BUILD = """
+BATS_SUPPORT_BUILD_CONTENT = """
 filegroup(
     name = "load_files",
     srcs = [
@@ -104,9 +104,10 @@ def bazel_bats_dependencies(
     if not sha256:
         fail("sha256 for bats-core was not supplied.")
 
-    http_archive(
+    maybe(
+        http_archive,
         name = "bats_core",
-        build_file_content = _BATS_CORE_BUILD,
+        build_file_content = BATS_CORE_BUILD_CONTENT,
         urls = [
             "https://github.com/bats-core/bats-core/archive/refs/tags/v%s.tar.gz" % version,
         ],
@@ -119,9 +120,10 @@ def bazel_bats_dependencies(
             fail("bats-assert version was set, but was missing set version for dependency bats-support.")
         if not bats_assert_sha256:
             fail("sha256 for bats-assert was not supplied.")
-        http_archive(
+        maybe(
+            http_archive,
             name = "bats_assert",
-            build_file_content = _BATS_ASSERT_BUILD,
+            build_file_content = BATS_ASSERT_BUILD_CONTENT,
             sha256 = bats_assert_sha256,
             strip_prefix = "bats-assert-%s" % bats_assert_version,
             urls = [
@@ -131,9 +133,10 @@ def bazel_bats_dependencies(
     if bats_support_version:
         if not bats_support_sha256:
             fail("sha256 for bats-support was not supplied.")
-        http_archive(
+        maybe(
+            http_archive,
             name = "bats_support",
-            build_file_content = _BATS_SUPPORT_BUILD,
+            build_file_content = BATS_SUPPORT_BUILD_CONTENT,
             sha256 = bats_support_sha256,
             strip_prefix = "bats-support-%s" % bats_support_version,
             urls = [


### PR DESCRIPTION
* Making BUILD file content strings public (removing leading `_`) in `deps.bzl`.
  * Adding `_CONTENT` suffix to variable names to be more clear and match the repo attribute name.
* Wrapping dependency `http_archive` definitions with `maybe()`.

This is to more easily allow downstream projects to define the dependency targets (bats-core, etc) with slightly changed attributes if they want/need to.
Changing `urls` or adding `patches`, etc, can be done less verbosely by reusing BUILD file contents defined here. Applying changes can be done to only the necessary repos, others can still be loaded via `bazel_bats_dependencies()`.