### PR TITLE
fix: update the module version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
-module(name = "bazel_bats", version="0.36.0")
+module(name = "bazel_bats", version="0.36.3")
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "gazelle", version = "0.42.0")


### PR DESCRIPTION
I forgot to update the module.version field when tagging the release.