### PR TITLE
fix: publish directly to a pull request when publishing to my registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,8 @@ jobs:
       # This is the fork of `registry`. It can be the same repo.
       registry_fork: filmil/bazel-registry
       attest: false
+      # Publish directly to a PR when publishing to my registry.
+      draft: false
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
The bar for publishing to my registry is really low, so publishing release PRs as drafts isn't super useful.