### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
-bazel_dep(name = "gazelle", version = "0.51.0")
+bazel_dep(name = "gazelle", version = "0.51.3")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.0", dev_dependency = True)
 bazel_dep(name = "rules_shell", version = "0.8.0")
 # -- bazel_dep definitions -- #
@@ -21,4 +21,4 @@ use_repo(bazel_bats, "bats_core", "bats_assert", "bats_support")
 
 # -- repo definitions -- #
 
-bazel_dep(name = "protobuf", version = "34.1")
+bazel_dep(name = "protobuf", version = "35.1")


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* gazelle: 0.51.0 -> 0.51.3
* protobuf: 34.1 -> 35.1